### PR TITLE
Allow overriding `X-Scope-OrgID` on a per-rule basis

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -140,6 +140,8 @@ default:: `null`
 
 If set, this value is sent as the `X-Scope-OrgID` header in all requests to Prometheus.
 
+This parameter can be overridden for each individual rule by setting the `prometheus_org_id` parameter on the rule.
+
 == `odoo.metered_billing_endpoint`
 [horizontal]
 type:: string
@@ -191,6 +193,7 @@ rule_appuio_managed_vcpu: <1>
         node_cpu_info{cloud_provider="%(cloud_provider)s", vshn_service_level="%(vshn_service_level)s"}
       )[59m:1m]
     )
+  prometheus_org_id: my-prom-org <10>
 ----
 +
 <1> Multiple rules can be defined in the dictionary, with the rule name serving as key.
@@ -202,6 +205,7 @@ rule_appuio_managed_vcpu: <1>
 <7> (Optional) The labels of the query result are applied to this pattern to generate the human readable item group description.
 <8> Odoo ID of the unit of measurement used.
 <9> The product params are applied to this pattern to generate one query for each product.
+<10> (Optional) If set, the value of the `X-Scope-OrgID` header used for Prometheus queries from this rule. Overrides the `prometheus.org_id` parameter.
 
 Dictionary containing rules by which to generate Prometheus queries.
 A rule corresponds to a single query template, from which queries for multiple products may be generated.

--- a/tests/golden/with-org-id/appuio-reporting/appuio-reporting/11_backfill.yaml
+++ b/tests/golden/with-org-id/appuio-reporting/appuio-reporting/11_backfill.yaml
@@ -58,8 +58,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-besteffort
                 - name: AR_QUERY
@@ -74,6 +72,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -144,8 +144,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-guaranteedavailability
                 - name: AR_QUERY
@@ -160,6 +158,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -230,8 +230,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-exoscale-besteffort
                 - name: AR_QUERY
@@ -246,6 +244,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -316,8 +316,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-exoscale-guaranteedavailability
                 - name: AR_QUERY
@@ -332,6 +330,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -402,8 +402,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-besteffort
                 - name: AR_QUERY
@@ -418,6 +416,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -488,8 +488,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-guaranteedavailability
                 - name: AR_QUERY
@@ -504,6 +502,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -574,8 +574,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-openstack-besteffort
                 - name: AR_QUERY
@@ -590,6 +588,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -660,8 +660,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-openstack-guaranteedavailability
                 - name: AR_QUERY
@@ -676,6 +674,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -746,8 +746,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-besteffort
                 - name: AR_QUERY
@@ -762,6 +760,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -832,8 +832,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-guaranteedavailability
                 - name: AR_QUERY
@@ -848,6 +846,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -918,8 +918,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-zero
                 - name: AR_QUERY
@@ -934,6 +932,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1004,8 +1004,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-standard
                 - name: AR_QUERY
@@ -1020,6 +1018,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1090,8 +1090,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-professional
                 - name: AR_QUERY
@@ -1106,6 +1104,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1176,8 +1176,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-premium
                 - name: AR_QUERY
@@ -1192,6 +1190,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1262,8 +1262,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-exoscale-zero
                 - name: AR_QUERY
@@ -1278,6 +1276,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1348,8 +1348,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-exoscale-standard
                 - name: AR_QUERY
@@ -1364,6 +1362,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1434,8 +1434,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-exoscale-professional
                 - name: AR_QUERY
@@ -1450,6 +1448,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1520,8 +1520,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-exoscale-premium
                 - name: AR_QUERY
@@ -1536,6 +1534,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1606,8 +1606,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-zero
                 - name: AR_QUERY
@@ -1622,6 +1620,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1692,8 +1692,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-standard
                 - name: AR_QUERY
@@ -1708,6 +1706,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1778,8 +1778,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-professional
                 - name: AR_QUERY
@@ -1794,6 +1792,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1864,8 +1864,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-premium
                 - name: AR_QUERY
@@ -1880,6 +1878,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -1950,8 +1950,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-openstack-zero
                 - name: AR_QUERY
@@ -1966,6 +1964,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2036,8 +2036,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-openstack-standard
                 - name: AR_QUERY
@@ -2052,6 +2050,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2122,8 +2122,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-openstack-professional
                 - name: AR_QUERY
@@ -2138,6 +2136,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2208,8 +2208,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-openstack-premium
                 - name: AR_QUERY
@@ -2224,6 +2222,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2294,8 +2294,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-standard
                 - name: AR_QUERY
@@ -2310,6 +2308,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2380,8 +2380,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-vsphere-professional
                 - name: AR_QUERY
@@ -2396,6 +2394,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2466,8 +2466,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-worker-vcpu-cloudscale-besteffort
                 - name: AR_QUERY
@@ -2482,6 +2480,8 @@ spec:
                     % labels
                 - name: AR_UNIT_ID
                   value: '300'
+                - name: AR_ORG_ID
+                  value: foo-org
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2552,8 +2552,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-cloudscale-zero
                 - name: AR_QUERY
@@ -2572,6 +2570,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2642,8 +2642,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-cloudscale-standard
                 - name: AR_QUERY
@@ -2662,6 +2660,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2732,8 +2732,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-cloudscale-professional
                 - name: AR_QUERY
@@ -2752,6 +2750,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2822,8 +2822,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-cloudscale-premium
                 - name: AR_QUERY
@@ -2842,6 +2840,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -2912,8 +2912,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-exoscale-zero
                 - name: AR_QUERY
@@ -2932,6 +2930,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3002,8 +3002,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-exoscale-standard
                 - name: AR_QUERY
@@ -3022,6 +3020,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3092,8 +3092,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-exoscale-professional
                 - name: AR_QUERY
@@ -3112,6 +3110,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3182,8 +3182,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-exoscale-premium
                 - name: AR_QUERY
@@ -3202,6 +3200,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3272,8 +3272,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-vsphere-zero
                 - name: AR_QUERY
@@ -3292,6 +3290,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3362,8 +3362,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-vsphere-standard
                 - name: AR_QUERY
@@ -3382,6 +3380,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3452,8 +3452,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-vsphere-professional
                 - name: AR_QUERY
@@ -3472,6 +3470,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3542,8 +3542,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-vsphere-premium
                 - name: AR_QUERY
@@ -3562,6 +3560,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3632,8 +3632,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-openstack-zero
                 - name: AR_QUERY
@@ -3652,6 +3650,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3722,8 +3722,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-openstack-standard
                 - name: AR_QUERY
@@ -3742,6 +3740,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3812,8 +3812,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-openstack-professional
                 - name: AR_QUERY
@@ -3832,6 +3830,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3902,8 +3902,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-openstack-premium
                 - name: AR_QUERY
@@ -3922,6 +3920,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -3992,8 +3992,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-vsphere-standard
                 - name: AR_QUERY
@@ -4012,6 +4010,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}
@@ -4082,8 +4082,6 @@ spec:
                     secretKeyRef:
                       key: url
                       name: prom-url
-                - name: AR_ORG_ID
-                  value: test-id
                 - name: AR_PRODUCT_ID
                   value: openshift-clusters-vsphere-professional
                 - name: AR_QUERY
@@ -4102,6 +4100,8 @@ spec:
                     - Cluster: %(cluster_id)s" % labels'
                 - name: AR_UNIT_ID
                   value: uom_uom_53_4a7e8f3e
+                - name: AR_ORG_ID
+                  value: test-id
               image: ghcr.io/appuio/appuio-reporting:v0.2.0
               name: backfill
               resources: {}

--- a/tests/with-org-id.yml
+++ b/tests/with-org-id.yml
@@ -22,6 +22,7 @@ parameters:
 
     rules:
       appuio_managed_vcpu:
+        prometheus_org_id: foo-org
         products:
           - product_id: 'openshift-worker-vcpu-cloudscale-besteffort'
             params:


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
