### PR TITLE
Make product parameters optional

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -94,10 +94,10 @@ else
   params.override_sales_order_id;
 
 local backfillCJ = function(rule, product, index)
-    local query = if std.objectHas(product, 'params') then
-      rule.query_pattern % product.params
-    else
-      rule.query_pattern;
+  local query = if std.objectHas(product, 'params') then
+    rule.query_pattern % product.params
+  else
+    rule.query_pattern;
 
   local itemDescJsonnet = if std.objectHas(rule, 'item_description_jsonnet') then
     rule.item_description_jsonnet

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -94,7 +94,10 @@ else
   params.override_sales_order_id;
 
 local backfillCJ = function(rule, product, index)
-  local query = rule.query_pattern % product.params;
+    local query = if std.objectHas(product, 'params') then
+      rule.query_pattern % product.params
+    else
+      rule.query_pattern;
 
   local itemDescJsonnet = if std.objectHas(rule, 'item_description_jsonnet') then
     rule.item_description_jsonnet

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -219,7 +219,7 @@ rule_appuio_managed_vcpu: <1>
 <1> Multiple rules can be defined in the dictionary, with the rule name serving as key.
 <2> All products whose corresponding queries can be generated from this rule should be listed here.
 <3> Odoo ID of the product for which usage is being queried.
-<4> Dictionary of arbitrary parameters describing the product. These will be applied to the `query_pattern`.
+<4> (Optional) Dictionary of arbitrary parameters describing the product. These will be applied to the `query_pattern`.
 <5> The labels of the query result are applied to this pattern to generate the instance ID.
 <6> (Optional) The labels of the query result are applied to this pattern to generate the human readable item description.
 <7> (Optional) The labels of the query result are applied to this pattern to generate the human readable item group description.


### PR DESCRIPTION
Make product parameters optional for queries where there are no extra parameters that need to be applied.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
